### PR TITLE
use express 3.x since 4.x doesn't meet the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "1.0.0",
     "author": "",
     "dependencies": {
-        "express": ">=3.0",
+        "express": ">=3.0 <= 4.0",
         "underscore": "",
         "uglify-js": "=2.2.5",
         "ws": ">=0.4",


### PR DESCRIPTION
I was getting the following error when using express 4.x so I forced 3.x and it worked fine

Error: Most middleware (like json) is no longer bundled with Express and must be installed separately. Please see https://github.com/senchalabs/connect#middleware.
    at Function.Object.defineProperty.get (/home/jm/DESAROLLO/ShareFest/node_modules/express/lib/express.js:89:13)
    at Object.<anonymous> (/home/jm/DESAROLLO/ShareFest/sharefest/server.js:27:17)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:902:3
